### PR TITLE
Development/master

### DIFF
--- a/Platform/Controllers/NotificationController.cs
+++ b/Platform/Controllers/NotificationController.cs
@@ -64,7 +64,7 @@ namespace Platform.Controllers
  
             using(var context = new NotificationContext(Context,Configuration))
             {
-                context.NotificationRead(request.Id, UserId);
+                context.NotificationRead(request.Id, UserId, request.ProjectId);
             }
             return new OutgoingJsonData{};
         }

--- a/Platform/DatabaseHandlers/Contexts/OutboundDetailsContext.cs
+++ b/Platform/DatabaseHandlers/Contexts/OutboundDetailsContext.cs
@@ -150,7 +150,7 @@ namespace Platform.DatabaseHandlers.Contexts
             }
            
     
-            var currentUser = "Unassigned";
+            var currentUser = "Inbound Bug Report tool";
             
             var notification = Context.Notifications.Add(new Notifications{
                 DateOfMessage = DateTime.Now,

--- a/Platform/DatabaseHandlers/WorkItemHandlers/WorkItemHadler.cs
+++ b/Platform/DatabaseHandlers/WorkItemHandlers/WorkItemHadler.cs
@@ -220,10 +220,11 @@ namespace RokonoControl.DatabaseHandlers.WorkItemHandlers
 
         public static bool AddNewWorkItem (IncomingWorkItem currentItem, RokonoControlContext Context,IConfiguration configuration, int userId)
         {
-                var relationshipId = default(int);
-            currentItem.SelectedChildren.ForEach(x=>{
-                                var relId = int.Parse(x.RelationShipId);
+            var currentUser = "Unassigned";
 
+            var relationshipId = default(int);
+            currentItem.SelectedChildren.ForEach(x=>{
+                var relId = int.Parse(x.RelationShipId);
                 var getItem = Context.WorkItemRelations.FirstOrDefault(y=>y.Id == relId);
                 if(getItem.RelationName == "Parent")
                     relationshipId = getItem.Id;
@@ -236,7 +237,11 @@ namespace RokonoControl.DatabaseHandlers.WorkItemHandlers
             var databaseItem = new WorkItem();
             databaseItem.Title = currentItem.Title;
             if(currentItem.AssignedUser != 0)
+            {
+                var userData = Context.UserAccounts.FirstOrDefault(x=>x.Id == currentItem.AssignedUser);
                 databaseItem.AssignedAccount = currentItem.AssignedUser;
+                currentUser = $"{userData.FirstName} {userData.LastName}";
+            }
             if(currentItem.WorktItemType != 0)
                 databaseItem.WorkItemTypeId = currentItem.WorktItemType;
             if(!string.IsNullOrEmpty(currentItem.State))
@@ -390,7 +395,6 @@ namespace RokonoControl.DatabaseHandlers.WorkItemHandlers
                             
                     }
                 });
-            var currentUser = "Unassigned";
             
             var notification = Context.Notifications.Add(new Notifications{
                 DateOfMessage = DateTime.Now,

--- a/Platform/Views/Shared/Components/ChatComponents/ChatSidebar/Default.cshtml
+++ b/Platform/Views/Shared/Components/ChatComponents/ChatSidebar/Default.cshtml
@@ -20,6 +20,9 @@
         width: 100%;
         margin: 0;
     }
+    #NoteEditorText{
+        min-height:33vh;
+    }
 </style>`
 
 <!-- sidebar element declaration -->
@@ -74,7 +77,7 @@
 
 <div class="main-content-chat" id="main-chatwindow" style="min-height: 92.142vh; top: -20px;">
     <div class="sidebar-content">
-        @await Component.InvokeAsync("Notes", @ProjectId)
+        @*@await Component.InvokeAsync("Notes", @ProjectId)*@
 
         <div class="row" id="MainChatContent">
             @await Component.InvokeAsync("ChatWIndow", new IncomingIdRequest{

--- a/Platform/Views/Shared/Components/NotificationPanel/Default.cshtml
+++ b/Platform/Views/Shared/Components/NotificationPanel/Default.cshtml
@@ -172,7 +172,7 @@
                     
                     <tr>
                         <td style="text-align:justify; max-width:85px;"> ${content} </td>
-                        <td style="text-align:center;"><span onclick="RemoveNotification(${id})" class="CloseBtn"></span></td>
+                        @* <td style="text-align:center;"><span onclick="RemoveNotification(${id})" class="CloseBtn"></span></td> *@
 
                     </tr>
                 </tbody>
@@ -226,6 +226,7 @@
 
     function InitiliazeNotificationGrid(data)
     {
+        
         var bindingData  = [];
         data.forEach(x=>{
             var currentData;
@@ -234,14 +235,16 @@
                     title: "Personal Message",
                     content: x.notification.content, 
                     cssClass: 'e-toast-info',
-                    icon: 'PM'
+                    icon: 'PM',
+                    id:x.notification.id
                 };
             if(x.notification.notificationType === 2)
                 currentData = {
                     title: "Assigned Item",
                     content: x.notification.content, 
                     cssClass: 'e-toast-success',
-                    icon: 'AI'
+                    icon: 'AI',
+                    id:x.notification.id
                 };
 
             if(x.notification.notificationType === 3)
@@ -249,14 +252,16 @@
                     title: "Created Work Item",
                     content: x.notification.content, 
                     cssClass: 'e-toast-warning',
-                    icon: 'CW'
+                    icon: 'CW',
+                    id:x.notification.id
                 };
             if(x.notification.notificationType === 4)
                 currentData ={
                     title: "Updated Work Item",
                     content: x.notification.content, 
                     cssClass: 'e-toast-danger',
-                    icon: 'UW'
+                    icon: 'UW',
+                    id:x.notification.id
                 };
             if(x.isRead === 0)
                 toasts.push(currentData);
@@ -290,7 +295,8 @@
         var newCount = parseInt(countA) -1;
         $("#NotificationCount").html(newCount);
         var dto = {
-            "Id": id
+            "Id": id,
+            "ProjectId":@ProjectId
             
         }
         $.ajax({
@@ -358,6 +364,11 @@
     function onclose (e){
         if (e.toastContainer.childElementCount === 0 ) {
             document.getElementById('hideTosat').style.display = 'none';
+             
+            if(e.options.id !== undefined)
+            {
+                RemoveNotification(e.options.id);
+            }
         }
      }
    


### PR DESCRIPTION
adding a fix to resolve bug 20147, Bug 19139 and resolving an issue where notification cards and notification grid items get duplicated because a notification can belong both to a given user and the project itself thus gets loaded twice, now notifications that already have been loaded initially either for the user or the project will get ignored and wont be duplicated.